### PR TITLE
Use object shorthand for properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ function simpleBinHelp (options, cliArguments) {
   }
 
   if (pkg && pkg.name && pkg.version) {
-    updateNotifier({ pkg: pkg }).notify()
+    updateNotifier({ pkg }).notify()
   }
 
   var minArguments = options.minArguments ||

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -33,7 +33,7 @@ describe('simple bin help', function () {
     var options = {
       minArguments: 1,
       noExit: true,
-      onFail: onFail
+      onFail
     }
     var cliArguments = []
     la(!simpleHelp(options, cliArguments), 'not enough arguments')


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166
